### PR TITLE
本番環境でNullエラーが起こっていたので、安全ナビゲーション演算子を追加

### DIFF
--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -14,7 +14,7 @@ class UserController < ApplicationController
 
     @profile.assign_attributes(
       has_partner: params[:profile]&.dig(:has_partner) || false,
-      unique_id: @profile.unique_id || SecureRandom.hex(4),
+      unique_id: @profile&.unique_id || SecureRandom.hex(4),
       friend_requests: params[:profile][:friend_requests] || [],
       friends: params[:profile][:friends] || []
     )   


### PR DESCRIPTION
@profile.assign_attributes(
      has_partner: params[:profile]&.dig(:has_partner) || false,
      unique_id: @profile.unique_id || SecureRandom.hex(4),
      friend_requests: params[:profile][:friend_requests] || [],
      friends: params[:profile][:friends] || []
    )  

１行レビューないが変更点は
has_partner: params[:profile]&.dig(:has_partner) || false,
      unique_id: @profile.unique_id || SecureRandom.hex(4),

この２箇所

背景
herokuにデプロイ後、プロフィールを作成する時最初の処理で必ず
Nullが入るためエラーが返ってきたので、まず、Nullを代入してから値を入れる
ように安全ナビゲーション演算子追加