### PR TITLE
無限ループの修正

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,5 +1,6 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
-# class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  
+  # class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def line
     Rails.logger.debug "LINE_CLIENT_ID from ENV in controller: #{ENV['LINE_CLIENT_ID']}"
     basic_action
@@ -7,7 +8,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   private
-  
+
   def basic_action
     @omniauth = request.env["omniauth.auth"]
     unless @omniauth
@@ -20,25 +21,25 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       if @user.email.blank?
         email = @omniauth["info"]["email"] ? @omniauth["info"]["email"] : "#{@omniauth["uid"]}-#{@omniauth["provider"]}@example.com"
         @user = current_user || User.create!(
-        provider: @omniauth["provider"], 
-        uid: @omniauth["uid"], 
-        email: email, 
-        name: @omniauth["info"]["name"], 
-        password: Devise.friendly_token[0, 20], 
-        image: @omniauth["info"]["image"]
+          provider: @omniauth["provider"], 
+          uid: @omniauth["uid"], 
+          email: email, 
+          name: @omniauth["info"]["name"], 
+          password: Devise.friendly_token[0, 20], 
+          image: @omniauth["info"]["image"]
         )
-        
       end
       @user.set_values(@omniauth)
       sign_in(:user, @user)
+      #　無限ループを防ぐ
+      if request.path != confirm_user_path
+        if @user.profile&.id.present?
+          redirect_to confirm_user_path
+        else
+          redirect_to expendable_items_path
+        end
+      end
     end
-    #ログイン後のflash messageとリダイレクト先を設定
-    if @user.profile&.id.present?
-      redirect_to confirm_user_path
-    else
-      redirect_to expendable_items_path
-    end
-
   end
 
   def fake_email(uid, provider)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,8 +80,8 @@ Rails.application.configure do
   # config.generators.apply_rubocop_autocorrect_after_generate!
 
   #heroku用
-  config.hosts << "line-text-d66b83e480a5.herokuapp.com"
+  # config.hosts << "line-text-d66b83e480a5.herokuapp.com"
 
   #開発用
-  # config.hosts << "d88a-240a-61-61a3-5182-bc78-eaf-2e50-aaa4.ngrok-free.app"
+  config.hosts << "ad96-153-212-244-139.ngrok-free.app"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,13 @@ Rails.application.routes.draw do
 
   # 🔹 Deviseのログインページをrootに設定（エラー回避）
   devise_scope :user do
-    root to: "devise/sessions#new"  # ✅ 修正：このブロック内で `root` を定義
+    authenticated :user do
+      root to: "user#confirm", as: :authenticated_root
+    end
+    # 未ログインユーザーは sign_in
+    unauthenticated do
+      root to: "devise/sessions#new"
+    end
   end
 
   get "/user/new", to: 'user#new', as: :expendable_items
@@ -15,7 +21,8 @@ Rails.application.routes.draw do
 
   get "/user/confirm", to: 'user#confirm', as: :confirm_user
 
-  #  https://c151-153-212-244-139.ngrok-free.app/users/sign_in
+  # https://ad96-153-212-244-139.ngrok-free.app/users/sign_in
+  # https://line-text-d66b83e480a5.herokuapp.com/users/auth/line/callback コールバッグメモ
   
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
@@ -29,6 +36,4 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
-
-
 end


### PR DESCRIPTION
概要
herokuでの環境で確認ページに飛ぶと無限ループが発生していたので
確認ページに飛ぶ際に条件を追加しい、ルートにも明示的にログイン状態を読み込ませ
ルート先を指定

