### PR TITLE
Main 20250329

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,0 +1,4 @@
+class MessagesController < ApplicationController
+  def thank_you
+  end
+end

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -41,13 +41,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @user.set_values(@omniauth)
       sign_in(:user, @user)
       
-      #　無限ループを防ぐ
-      if request.path != confirm_user_path
-        if @user.profile&.id.present?
-          redirect_to confirm_user_path
-        else
-          redirect_to expendable_items_path
-        end
+      if @user.profile.completed?
+        redirect_to confirm_user_path
+      else
+        redirect_to expendable_items_path
       end
     end
   end

--- a/app/controllers/user_controller.rb
+++ b/app/controllers/user_controller.rb
@@ -40,5 +40,17 @@ class UserController < ApplicationController
   def confirm
     @profile = current_user.profile || current_user.create_profile!(unique_id: SecureRandom.hex(4), has_partner: false)
   end
+
+  def confirm_messes
+    @profile = current_user.profile
+    # 確認ボタン押したら、プロフィールテーブルcompleted: true
+    if @profile.update(completed: true)
+      redirect_to thank_you_path, notice:
+    else
+      redirect_to confirm_user_path
+    end
+  end
   
+  def thank_you
+  end
 end

--- a/app/helpers/messages_helper.rb
+++ b/app/helpers/messages_helper.rb
@@ -1,0 +1,2 @@
+module MessagesHelper
+end

--- a/app/views/user/confirm.html.erb
+++ b/app/views/user/confirm.html.erb
@@ -14,7 +14,8 @@
       <p><strong>生年月日</strong></p> <p><%= @profile.birthdate.strftime("%Y年 %m月 %d日") if @profile.birthdate %></p>
 
       <!-- 確認ボタン -->
-      <%= button_to "登録", expendable_items_path, method: :post, class: "btn btn-primary btn-primary_2" %>
+      <%= button_to "登録", complete_profile_path, method: :patch, class: "btn btn-primary btn-primary_2" %>
+
       <!-- 修正ページへ戻るリンク -->
       <%= link_to "戻る", expendable_items_path, class: "btn-secondary" %>
   </div>

--- a/app/views/user/thank_you.html.erb
+++ b/app/views/user/thank_you.html.erb
@@ -1,0 +1,2 @@
+<h1>Messages#thank_you</h1>
+<p>Find me in app/views/messages/thank_you.html.erb</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  get "messages/thank_you"
 
   devise_for :users, controllers: {
     omniauth_callbacks: "omniauth_callbacks"
@@ -21,7 +22,7 @@ Rails.application.routes.draw do
 
   get "/user/confirm", to: 'user#confirm', as: :confirm_user
 
-  # https://ce33-240a-61-1c7-a03f-6870-fe0f-426c-e694.ngrok-free.app/users/sign_in
+  # https://85f6-153-222-142-57.ngrok-free.app/users/sign_in
   # https://line-text-d66b83e480a5.herokuapp.com/users/auth/line/callback コールバッグメモ
   
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,9 +1,8 @@
 Rails.application.routes.draw do
-  get "messages/thank_you"
-
+  
   devise_for :users, controllers: {
     omniauth_callbacks: "omniauth_callbacks"
-  }, skip: [:passwords, :registrations] #明日おかしかったら消す
+  }, skip: [:passwords, :registrations]
 
   # 🔹 Deviseのログインページをrootに設定（エラー回避）
   devise_scope :user do
@@ -16,13 +15,20 @@ Rails.application.routes.draw do
     end
   end
 
+  # 証人画面 > 新規ページ
   get "/user/new", to: 'user#new', as: :expendable_items
 
-  patch 'users/update_or_create', to: 'user#update_or_create', as: 'update_or_create_user'
-
+  # 新規作成ページから入力データを読み込みテーブルに保存
+  patch 'users/update_or_create', to: 'user#update_or_create', as: 
+  'update_or_create_user'
+  # 新規ページ > プロフィール作成確認ページ
   get "/user/confirm", to: 'user#confirm', as: :confirm_user
+  # 確認ページ確認ボタン押した後、プロフィールテーブルcomplete: ture
+  patch "user/confirm_messes", to: "user#confirm_messes", as: :complete_profile
+  # プロフィール確認ページ > メッセージページ
+  get "user/thank_you", to: "user#thank_you", as: :thank_you
 
-  # https://85f6-153-222-142-57.ngrok-free.app/users/sign_in
+  # https://c108-153-222-142-57.ngrok-free.app/users/sign_in
   # https://line-text-d66b83e480a5.herokuapp.com/users/auth/line/callback コールバッグメモ
   
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20250329070322_add_completed_to_profiles.rb
+++ b/db/migrate/20250329070322_add_completed_to_profiles.rb
@@ -1,0 +1,5 @@
+class AddCompletedToProfiles < ActiveRecord::Migration[7.2]
+  def change
+    add_column :profiles, :completed, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_16_090845) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_29_070322) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -48,6 +48,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_16_090845) do
     t.text "friends"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "completed", default: false, null: false
     t.index ["user_id"], name: "index_profiles_on_user_id"
   end
 

--- a/test/controllers/messages_controller_test.rb
+++ b/test/controllers/messages_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class MessagesControllerTest < ActionDispatch::IntegrationTest
+  test "should get thank_you" do
+    get messages_thank_you_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
概要
・証人後、新規ページではなく確認ページにすぐ飛んでしまっていたので、ルーティングの修正
・メッセージページの作成

不具合
・ライン証人後、新規ページではなく確認ページに飛ぶようになっていた
原因
・プロフィールが作成されていたら新規ページスキップし確認ページに飛ぶよう設定したが
　以前の修正で、プロフィールをオムニーチコントローラーで自動作成してしまったため、新規ページに飛ばなくなりました。
→対策として、プロフィールテーブルにboolの列を追加、そこでプロフィールが新規ページに飛ぶのか
　確認ページに飛ぶのかを判断、


